### PR TITLE
Add iNes Mapper 002 (UNROM) Support

### DIFF
--- a/src/cartridge.cpp
+++ b/src/cartridge.cpp
@@ -3,6 +3,7 @@
 #include "cpu.hpp"
 #include "mappers/mapper0.hpp"
 #include "mappers/mapper1.hpp"
+#include "mappers/mapper2.hpp"
 #include "mappers/mapper4.hpp"
 #include "ppu.hpp"
 #include "cartridge.hpp"
@@ -52,6 +53,7 @@ void load(const char* fileName)
     {
         case 0:  mapper = new Mapper0(rom); break;
         case 1:  mapper = new Mapper1(rom); break;
+        case 2:  mapper = new Mapper2(rom); break;
         case 4:  mapper = new Mapper4(rom); break;
     }
 

--- a/src/mappers/mapper2.cpp
+++ b/src/mappers/mapper2.cpp
@@ -1,0 +1,40 @@
+#include "ppu.hpp"
+#include "mappers/mapper2.hpp"
+
+/* Based off of https://wiki.nesdev.com/w/index.php/UxROM */
+
+/* Apply the registers state */
+void Mapper2::apply()
+{
+   /*
+    * 16 kb PRG ROM Banks
+    * 0x8000 - 0xBFFF swappable
+    * 0xC000 - 0xFFFF fixed
+    */
+    map_prg<16>(0, regs[0] & 0xF);
+    map_prg<16>(1,           0xF);
+
+    /* 8k of CHR */
+    map_chr<8>(0, 0);
+
+    /* mirroring is based on the header (soldered) */
+    set_mirroring(vertical_mirroring?PPU::VERTICAL:PPU::HORIZONTAL);
+}
+
+u8 Mapper2::write(u16 addr, u8 v)
+{
+    /* check for bus contingency? (addr & 0x8000 == v?) nah */
+
+    /* bank switching */
+    if (addr & 0x8000)
+    {
+        regs[0] = v;
+        apply();
+    }
+    return v;
+}
+
+u8 Mapper2::chr_write(u16 addr, u8 v)
+{
+    return chr[addr] = v;
+}

--- a/src/mappers/mapper2.hpp
+++ b/src/mappers/mapper2.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include "mapper.hpp"
+
+
+class Mapper2 : public Mapper
+{
+    u8 regs[1];
+    bool vertical_mirroring;
+
+    void apply();
+
+  public:
+    Mapper2(u8* rom) : Mapper(rom)
+    {
+        regs[0] = 0;
+        vertical_mirroring = rom[7] & 0x01;
+        apply();
+    }
+
+    u8 write(u16 addr, u8 v);
+    u8 chr_write(u16 addr, u8 v);
+};


### PR DESCRIPTION
Add support for iNES Mapper 002, which is a simpler version of Mapper 1.
There is 16kB of fixed space mapped from $C000-FFFF and 16kB of mappable
space from $8000-$BFFF. This space is mapped simply by writing to
0x8000. There is 8K of CHR ROM, and no RAM or anything funny.