### PR TITLE
Fix mirroring for Mapper 002 and 003

### DIFF
--- a/src/mappers/mapper2.hpp
+++ b/src/mappers/mapper2.hpp
@@ -13,7 +13,7 @@ class Mapper2 : public Mapper
     Mapper2(u8* rom) : Mapper(rom)
     {
         regs[0] = 0;
-        vertical_mirroring = rom[7] & 0x01;
+        vertical_mirroring = rom[6] & 0x01;
         apply();
     }
 

--- a/src/mappers/mapper3.hpp
+++ b/src/mappers/mapper3.hpp
@@ -13,7 +13,7 @@ class Mapper3 : public Mapper
     Mapper3(u8* rom) : Mapper(rom)
     {
         PRG_size_16k = rom[4] == 1;
-        vertical_mirroring = rom[7] & 0x01;
+        vertical_mirroring = rom[6] & 0x01;
         regs[0] = 0;
         apply();
     }


### PR DESCRIPTION
I was reading the wrong byte in the header to determine the mirroring
for these mappers, which have hard-wired (soldered) mirroring. Reading
the correct byte unsurprisingly corrects issues.

Tested: Contra, Castlevania, Duck Tales