### PR TITLE
Change Invalid OPcodes to a print statement + NOP

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
 #include "apu.hpp"
 #include "cartridge.hpp"
 #include "joypad.hpp"
@@ -229,7 +230,12 @@ void exec()
         case 0xF1: return SBC<izy>()  ;  case 0xF5: return SBC<zpx>()  ;
         case 0xF6: return INC<zpx>()  ;  case 0xF8: return flag<D,1>() ;
         case 0xF9: return SBC<aby>()  ;  case 0xFD: return SBC<abx>()  ;
-        case 0xFE: return INC<_abx>() ;  default:   return exit(1)     ;
+        case 0xFE: return INC<_abx>() ;
+        default:
+        {
+          std::cout << "Invalid OPcode! PC: " << PC << " OPcode: 0x" << std::hex << (int)rd(PC-1) << "\n";
+          return NOP();
+        }
     }
 }
 


### PR DESCRIPTION
Some games (such as Puzznic) use invalid opcodes--there's a ton of them
documented in detail here:
* http://www.ffd2.com/fridge/docs/6502-NMOS.extra.opcodes
and
* http://wiki.nesdev.com/w/index.php/CPU_unofficial_opcodes#Games_using_unofficial_opcodes

Note that most of the opcodes used are NOPs, so I default to NOP +
warning. Proper emulation of all of the illegal opcodes is probably
warranted for full compatibility.

This fixes #26