### PR TITLE
Fix some bugs

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -30,7 +30,7 @@ inline void tick() { PPU::step(); PPU::step(); PPU::step(); remainingCycles--; }
 inline void upd_cv(u8 x, u8 y, s16 r) { P[C] = (r>0xFF); P[V] = ~(x^y) & (x^r) & 0x80; }
 inline void upd_nz(u8 x)              { P[N] = x & 0x80; P[Z] = (x == 0);              }
 // Does adding I to A cross a page?
-inline bool cross(u16 a, u8 i) { return ((a+i) & 0xFF00) != ((a & 0xFF00)); }
+template<typename Offset> inline bool cross(u16 a, Offset i) { return ((a+i) & 0xFF00) != ((a & 0xFF00)); }
 
 /* Memory access */
 void dma_oam(u8 bank);
@@ -141,7 +141,7 @@ void RTI() { PLP(); PC =  pop() | (pop() << 8);         }
 template<Flag f, bool v> void flag() { P[f] = v; T; }  // Clear and set flags.
 template<IntType t> void INT()
 {
-    T; if (t != BRK) T;  // BRK already performed the fetch.
+    T; if (t != BRK) T; else PC++;  // BRK already performed the fetch.
     if (t != RESET)  // Writes on stack are inhibited on RESET.
     {
         push(PC >> 8); push(PC & 0xFF);

--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -178,13 +178,16 @@ void eval_sprites()
         // If the sprite is in the scanline, copy its properties into secondary OAM:
         if (line >= 0 and line < spr_height())
         {
-            secOam[n].id   = i;
-            secOam[n].y    = oamMem[i*4 + 0];
-            secOam[n].tile = oamMem[i*4 + 1];
-            secOam[n].attr = oamMem[i*4 + 2];
-            secOam[n].x    = oamMem[i*4 + 3];
-
-            if (++n >= 8)
+            if (n < 8)
+            {
+                secOam[n].id   = i;
+                secOam[n].y    = oamMem[i * 4 + 0];
+                secOam[n].tile = oamMem[i * 4 + 1];
+                secOam[n].attr = oamMem[i * 4 + 2];
+                secOam[n].x    = oamMem[i * 4 + 3];
+                n++;
+            }
+            else
             {
                 status.sprOvf = true;
                 break;


### PR DESCRIPTION
- Branch instructions may jump incorrectly and take the wrong cycles, this is because `cross` function always takes offset paramenter as `u8`, it should be `s8` in branch instructions.
- PC is incremented twice before being pushed by BRK, fixes #38.
- Sprite overflow flag should be set when there are **more than** 8 sprites, instead of just 8, see [nesdev wiki](https://wiki.nesdev.org/w/index.php?title=PPU_sprite_evaluation#Overview).