### PR TITLE
Switch to SDL Gamepad instead of SDL Joystick

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The main menu includes a **Reset** option to reload and restart the current ROM 
 ### Savestate Support
 LaiNES includes savestate functionality accessible through the main menu (**Save State** and **Load State** options). Savestates preserve the complete emulator state including CPU, PPU, APU, mapper state, and expansion audio. Savestates are automatically stored per-ROM and can be loaded at any time.
 
-The size of the window and the controls are customizable. LaiNES supports multiple controllers and should work with joysticks as well. The default controls for the first player are as follows:
+The size of the window and the controls are customizable. LaiNES uses SDL2's GameController API, which provides out-of-the-box support for most modern controllers (Xbox, PlayStation, Switch, etc.) with correct button mapping and D-pad support. Up to two controllers are supported. The default controls for the first player are as follows:
 
 ![Controller Settings](http://i.imgur.com/ERQ2nmJ.png)
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -23,14 +23,14 @@ SDL_Scancode KEY_UP    [] = { SDL_SCANCODE_UP,     SDL_SCANCODE_ESCAPE };
 SDL_Scancode KEY_DOWN  [] = { SDL_SCANCODE_DOWN,   SDL_SCANCODE_ESCAPE };
 SDL_Scancode KEY_LEFT  [] = { SDL_SCANCODE_LEFT,   SDL_SCANCODE_ESCAPE };
 SDL_Scancode KEY_RIGHT [] = { SDL_SCANCODE_RIGHT,  SDL_SCANCODE_ESCAPE };
-int BTN_UP    [] = { -1, -1 };
-int BTN_DOWN  [] = { -1, -1 };
-int BTN_LEFT  [] = { -1, -1 };
-int BTN_RIGHT [] = { -1, -1 };
-int BTN_A     [] = { -1, -1 };
-int BTN_B     [] = { -1, -1 };
-int BTN_SELECT[] = { -1, -1 };
-int BTN_START [] = { -1, -1 };
+int BTN_UP    [] = { SDL_CONTROLLER_BUTTON_DPAD_UP,    SDL_CONTROLLER_BUTTON_DPAD_UP };
+int BTN_DOWN  [] = { SDL_CONTROLLER_BUTTON_DPAD_DOWN,  SDL_CONTROLLER_BUTTON_DPAD_DOWN };
+int BTN_LEFT  [] = { SDL_CONTROLLER_BUTTON_DPAD_LEFT,  SDL_CONTROLLER_BUTTON_DPAD_LEFT };
+int BTN_RIGHT [] = { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, SDL_CONTROLLER_BUTTON_DPAD_RIGHT };
+int BTN_A     [] = { SDL_CONTROLLER_BUTTON_A,          SDL_CONTROLLER_BUTTON_A };
+int BTN_B     [] = { SDL_CONTROLLER_BUTTON_B,          SDL_CONTROLLER_BUTTON_B };
+int BTN_SELECT[] = { SDL_CONTROLLER_BUTTON_BACK,       SDL_CONTROLLER_BUTTON_BACK };
+int BTN_START [] = { SDL_CONTROLLER_BUTTON_START,       SDL_CONTROLLER_BUTTON_START };
 bool useJoystick[] = { false, false };
 
 
@@ -98,14 +98,14 @@ void load_settings()
         useJoystick[p] = (ini.GetValue(section, "usejoy", "no"))[0] == 'y';
         if (useJoystick[p])
         {
-            BTN_UP[p] = atoi(ini.GetValue(section, "UP", "-1"));
-            BTN_DOWN[p] = atoi(ini.GetValue(section, "DOWN", "-1"));
-            BTN_LEFT[p] = atoi(ini.GetValue(section, "LEFT", "-1"));
-            BTN_RIGHT[p] = atoi(ini.GetValue(section, "RIGHT", "-1"));
-            BTN_A[p] = atoi(ini.GetValue(section, "A", "-1"));
-            BTN_B[p] = atoi(ini.GetValue(section, "B", "-1"));
-            BTN_SELECT[p] = atoi(ini.GetValue(section, "SELECT", "-1"));
-            BTN_START[p] = atoi(ini.GetValue(section, "START", "-1"));
+            BTN_UP[p] = atoi(ini.GetValue(section, "UP", "11"));
+            BTN_DOWN[p] = atoi(ini.GetValue(section, "DOWN", "12"));
+            BTN_LEFT[p] = atoi(ini.GetValue(section, "LEFT", "13"));
+            BTN_RIGHT[p] = atoi(ini.GetValue(section, "RIGHT", "14"));
+            BTN_A[p] = atoi(ini.GetValue(section, "A", "0"));
+            BTN_B[p] = atoi(ini.GetValue(section, "B", "1"));
+            BTN_SELECT[p] = atoi(ini.GetValue(section, "SELECT", "4"));
+            BTN_START[p] = atoi(ini.GetValue(section, "START", "6"));
         }
         else
         {

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -20,7 +20,7 @@ SDL_Texture* background;
 TTF_Font* font;
 u8 const* keys;
 Sound_Queue* soundQueue;
-SDL_Joystick* joystick[] = { nullptr, nullptr };
+SDL_GameController* controller[] = { nullptr, nullptr };
 
 // Menus:
 Menu* menu;
@@ -83,8 +83,8 @@ void set_scaling_mode(bool smooth)
     recreate_menu(videoMenu);
     recreate_menu(keyboardMenu[0]);
     recreate_menu(keyboardMenu[1]);
-    if (joystick[0]) recreate_menu(joystickMenu[0]);
-    if (joystick[1]) recreate_menu(joystickMenu[1]);
+    if (controller[0]) recreate_menu(joystickMenu[0]);
+    if (controller[1]) recreate_menu(joystickMenu[1]);
     recreate_menu(fileMenu);
 }
 
@@ -112,7 +112,7 @@ void set_aspect_stretch(bool enabled)
 void init()
 {
     // Initialize graphics system:
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK);
+    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER);
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scaling_mode ? "1" : "0");
 
     // Set window class for Wayland/X11 to match .desktop file
@@ -121,8 +121,9 @@ void init()
 
     TTF_Init();
 
-    for (int i = 0; i < SDL_NumJoysticks(); i++)
-        joystick[i] = SDL_JoystickOpen(i);
+    for (int i = 0, ci = 0; i < SDL_NumJoysticks() && ci < 2; i++)
+        if (SDL_IsGameController(i))
+            controller[ci++] = SDL_GameControllerOpen(i);
 
     APU::init();
     soundQueue = new Sound_Queue;
@@ -205,7 +206,7 @@ void init()
     {
         keyboardMenu[i] = new Menu;
         keyboardMenu[i]->add(new Entry("<", []{ menu = settingsMenu; }));
-        if (joystick[i] != nullptr)
+        if (controller[i] != nullptr)
             keyboardMenu[i]->add(new Entry("Joystick >", [=]{ menu = joystickMenu[i]; useJoystick[i] = true; }));
         keyboardMenu[i]->add(new ControlEntry("Up",     &KEY_UP[i]));
         keyboardMenu[i]->add(new ControlEntry("Down",   &KEY_DOWN[i]));
@@ -216,7 +217,7 @@ void init()
         keyboardMenu[i]->add(new ControlEntry("Start",  &KEY_START[i]));
         keyboardMenu[i]->add(new ControlEntry("Select", &KEY_SELECT[i]));
 
-        if (joystick[i] != nullptr)
+        if (controller[i] != nullptr)
         {
             joystickMenu[i] = new Menu;
             joystickMenu[i]->add(new Entry("<", []{ menu = settingsMenu; }));
@@ -273,21 +274,21 @@ u8 get_joypad_state(int n)
     u8 j = 0;
     
     // Get normal controller input first
-    if (useJoystick[n])
+    if (useJoystick[n] && controller[n])
     {
-        j |= (SDL_JoystickGetButton(joystick[n], BTN_A[n]))      << 0;  // A.
-        j |= (SDL_JoystickGetButton(joystick[n], BTN_B[n]))      << 1;  // B.
-        j |= (SDL_JoystickGetButton(joystick[n], BTN_SELECT[n])) << 2;  // Select.
-        j |= (SDL_JoystickGetButton(joystick[n], BTN_START[n]))  << 3;  // Start.
+        j |= (SDL_GameControllerGetButton(controller[n], (SDL_GameControllerButton)BTN_A[n]))      << 0;  // A.
+        j |= (SDL_GameControllerGetButton(controller[n], (SDL_GameControllerButton)BTN_B[n]))      << 1;  // B.
+        j |= (SDL_GameControllerGetButton(controller[n], (SDL_GameControllerButton)BTN_SELECT[n])) << 2;  // Select.
+        j |= (SDL_GameControllerGetButton(controller[n], (SDL_GameControllerButton)BTN_START[n]))  << 3;  // Start.
 
-        j |= (SDL_JoystickGetButton(joystick[n], BTN_UP[n]))     << 4;  // Up.
-        j |= (SDL_JoystickGetAxis(joystick[n], 1) < -DEAD_ZONE)  << 4;
-        j |= (SDL_JoystickGetButton(joystick[n], BTN_DOWN[n]))   << 5;  // Down.
-        j |= (SDL_JoystickGetAxis(joystick[n], 1) >  DEAD_ZONE)  << 5;
-        j |= (SDL_JoystickGetButton(joystick[n], BTN_LEFT[n]))   << 6;  // Left.
-        j |= (SDL_JoystickGetAxis(joystick[n], 0) < -DEAD_ZONE)  << 6;
-        j |= (SDL_JoystickGetButton(joystick[n], BTN_RIGHT[n]))  << 7;  // Right.
-        j |= (SDL_JoystickGetAxis(joystick[n], 0) >  DEAD_ZONE)  << 7;
+        j |= (SDL_GameControllerGetButton(controller[n], (SDL_GameControllerButton)BTN_UP[n]))     << 4;  // Up.
+        j |= (SDL_GameControllerGetAxis(controller[n], SDL_CONTROLLER_AXIS_LEFTY) < -DEAD_ZONE)    << 4;
+        j |= (SDL_GameControllerGetButton(controller[n], (SDL_GameControllerButton)BTN_DOWN[n]))   << 5;  // Down.
+        j |= (SDL_GameControllerGetAxis(controller[n], SDL_CONTROLLER_AXIS_LEFTY) >  DEAD_ZONE)    << 5;
+        j |= (SDL_GameControllerGetButton(controller[n], (SDL_GameControllerButton)BTN_LEFT[n]))   << 6;  // Left.
+        j |= (SDL_GameControllerGetAxis(controller[n], SDL_CONTROLLER_AXIS_LEFTX) < -DEAD_ZONE)    << 6;
+        j |= (SDL_GameControllerGetButton(controller[n], (SDL_GameControllerButton)BTN_RIGHT[n]))  << 7;  // Right.
+        j |= (SDL_GameControllerGetAxis(controller[n], SDL_CONTROLLER_AXIS_LEFTX) >  DEAD_ZONE)    << 7;
     }
     else
     {
@@ -418,8 +419,8 @@ int query_button()
     while (true)
     {
         SDL_PollEvent(&e);
-        if (e.type == SDL_JOYBUTTONDOWN)
-            return e.jbutton.button;
+        if (e.type == SDL_CONTROLLERBUTTONDOWN)
+            return e.cbutton.button;
     }
 }
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -52,12 +52,17 @@ ControlEntry::ControlEntry(string action, SDL_Scancode* key) : key(key),
     this->keyEntry = new Entry(SDL_GetScancodeName(*key), []{});
 }
 
+static string btn_name(int b) {
+    const char* s = SDL_GameControllerGetStringForButton((SDL_GameControllerButton)b);
+    return s ? s : "?";
+}
+
 ControlEntry::ControlEntry(string action, int* button) : button(button),
     Entry::Entry(
         action,
-        [&]{ keyEntry->set_label(to_string(*(this->button) = query_button())); })
+        [&]{ keyEntry->set_label(btn_name(*(this->button) = query_button())); })
 {
-    this->keyEntry = new Entry(to_string(*button), []{});
+    this->keyEntry = new Entry(btn_name(*button), []{});
 }
 
 CycleEntry::CycleEntry(string prefix, int* value, int min_val, int max_val,


### PR DESCRIPTION
SDL2's joystick is fairly low-level, and it leads to issues with some controllers on some platforms--things like the d-pad not being mapped properly. This change switches to the gamepad API, which is a bit higher level, which brings with it the bonus of stable button mappings across platforms.