### PR TITLE
Enabling native Windows build support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,15 +1,31 @@
+import sys
 from os import environ
 
 VariantDir('build/src', 'src', duplicate=0)
 VariantDir('build/lib', 'lib', duplicate=0)
-flags = ['-O3', '-march=native', '-std=c++14']
+
+is_windows = sys.platform.startswith('win')
+
+if is_windows:
+    cxx       = 'clang-cl'
+    cxxflags  = ['/Ox', '/std:c++14']
+    cppflags  = []
+    linkflags = ['/SUBSYSTEM:CONSOLE']
+    defines   = ['SDL_MAIN_HANDLED', '_CRT_SECURE_NO_WARNINGS']
+else:
+    cxx       = 'clang++'
+    cxxflags  = ['-O3', '-march=native', '-std=c++14']
+    cppflags  = ['-Wno-unused-value']
+    linkflags = cxxflags
+    defines   = []
 
 env = Environment(ENV       = environ,
-                  CXX       = 'clang++',
-                  CPPFLAGS  = ['-Wno-unused-value'],
-                  CXXFLAGS  = flags,
-                  LINKFLAGS = flags,
+                  CXX       = cxx,
+                  CPPFLAGS  = cppflags,
+                  CXXFLAGS  = cxxflags,
+                  LINKFLAGS = linkflags,
                   CPPPATH   = ['#simpleini', '#lib/include', '#src/include'],
+                  CPPDEFINES = defines,
                   LIBS      = ['SDL2', 'SDL2_image', 'SDL2_ttf'])
 
 env.Program('laines', Glob('build/*/*.cpp') + Glob('build/*/*/*.cpp'))

--- a/lib/include/blargg_common.h
+++ b/lib/include/blargg_common.h
@@ -8,6 +8,7 @@
 
 #ifndef BLARGG_COMMON_H
 #define BLARGG_COMMON_H
+#include <new>
 
 // Allow prefix configuration file *which can re-include blargg_common.h*
 // (probably indirectly).
@@ -142,7 +143,7 @@ const blargg_err_t blargg_success = 0;
 // BLARGG_NEW is used in place of 'new' to create objects. By default,
 // nothrow new is used.
 #ifndef BLARGG_NEW
-	#define BLARGG_NEW new (STD::nothrow)
+	#define BLARGG_NEW new (std::nothrow)
 #endif
 
 // BLARGG_BIG_ENDIAN and BLARGG_LITTLE_ENDIAN

--- a/lib/include/boost/cstdint.hpp
+++ b/lib/include/boost/cstdint.hpp
@@ -4,39 +4,18 @@
 #ifndef BOOST_CSTDINT_HPP
 #define BOOST_CSTDINT_HPP
 
-#if BLARGG_USE_NAMESPACE
-	#include <climits>
-#else
-	#include <limits.h>
-#endif
+#include <cstdint>
+#include <climits>
 
 BLARGG_BEGIN_NAMESPACE( boost )
 
-#if UCHAR_MAX != 0xFF || SCHAR_MAX != 0x7F
-#   error "No suitable 8-bit type available"
-#endif
-
-typedef unsigned char   uint8_t;
-typedef signed char     int8_t;
-
-#if USHRT_MAX != 0xFFFF
-#   error "No suitable 16-bit type available"
-#endif
-
-typedef short           int16_t;
-typedef unsigned short  uint16_t;
-
-#if ULONG_MAX == 0xFFFFFFFF
-	typedef long            int32_t;
-	typedef unsigned long   uint32_t;
-#elif UINT_MAX == 0xFFFFFFFF
-	typedef int             int32_t;
-	typedef unsigned int    uint32_t;
-#else
-#   error "No suitable 32-bit type available"
-#endif
+using ::uint8_t;
+using ::int8_t;
+using ::uint16_t;
+using ::int16_t;
+using ::uint32_t;
+using ::int32_t;
 
 BLARGG_END_NAMESPACE
 
 #endif
-

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,3 +1,4 @@
+#include <cerrno>
 #include <cstdlib>
 #include <SimpleIni.h>
 #include "config.hpp"
@@ -42,6 +43,9 @@ const char* get_config_path(char* buf, int buflen)
     if (!USE_CONFIG_DIR)
        return CONFIG_FALLBACK;
 
+#ifdef _WIN32
+    return CONFIG_FALLBACK;
+#else
     /* First, get the home directory */
     char homepath[CONFIG_PATH_MAX];
     char path[CONFIG_PATH_MAX];
@@ -70,6 +74,7 @@ const char* get_config_path(char* buf, int buflen)
     snprintf(buf, buflen, "%s/settings", path);
 
     return buf;
+#endif
 }
 
 

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -1,12 +1,18 @@
 #pragma once
-#include <cerrno>
-#include <sys/stat.h>
 #include <SDL2/SDL.h>
 
-#define CONFIG_DIR_DEFAULT_MODE      S_IRWXU | S_IRGRP |  S_IXGRP | S_IROTH | S_IXOTH
 #define USE_CONFIG_DIR true
 #define CONFIG_DIR_NAME "LaiNES" 
 #define CONFIG_FALLBACK ".laines-settings"
+
+#ifdef _WIN32
+  // Windows mkdir doesn't use POSIX modes; keep signature compatibility.
+  #define CONFIG_DIR_DEFAULT_MODE 0
+#else
+  #include <sys/stat.h>
+  #define CONFIG_DIR_DEFAULT_MODE (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)
+#endif
+
 /* PATH_MAX is a portability nightmare. */
 #define CONFIG_PATH_MAX 1024 
 


### PR DESCRIPTION
Split into two commits:
1) monkey-patching blargg_common.h to remove some compatibility stuff which both isn't needed with C++14 and causes issues with clang-cl

2) the actual changes to the sconstruct file and minor changes to config handling (Windows doesn't have XDG)

Fixes #27

Tested on/with:
```
clang version 21.1.8
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files\LLVM\bin
```

as well as 

```
clang version 21.1.8
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

and

```
Apple clang version 17.0.0 (clang-1700.0.13.5)
Target: arm64-apple-darwin24.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```
